### PR TITLE
No user agent support

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -13,6 +13,10 @@ function DeviceParser(req) {
     
     self.get_type = function() {
         var ua = self.user_agent();
+        // No user agent.
+        if(ua === undefined){
+        	return 'desktop';
+        }
         // Check if user agent is a smart TV - http://goo.gl/FocDk
         if (ua.match(/GoogleTV|SmartTV|Internet.TV|NetCast|NETTV|AppleTV|boxee|Kylo|Roku|DLNADOC|CE\-HTML/i)) {
         	return 'tv';


### PR DESCRIPTION
If a client doesn't send user agent information (haproxy httpchk in my case) I get this:

<code>
 at DeviceParser.self.get_type (/home/node_modules/express-device/lib/device.js:17:16)
    at Object.exports.capture [as handle](/home/node_modules/express-device/lib/device.js:79:34)
    at next (/home/node_modules/express/node_modules/connect/lib/proto.js:190:15)
    at Object.expressValidator [as handle](/home/node_modules/express-validator/lib/express_validator.js:140:10)
    at next (/home/node_modules/express/node_modules/connect/lib/proto.js:190:15)
    at Object.limit [as handle](/home/node_modules/express/node_modules/connect/lib/middleware/limit.js:53:5)
    at next (/home/node_modules/express/node_modules/connect/lib/proto.js:190:15)
    at multipart (/home/node_modules/express/node_modules/connect/lib/middleware/multipart.js:62:61)
    at module.exports (/home/node_modules/express/node_modules/connect/lib/middleware/bodyParser.js:57:9)
    at urlencoded (/home/node_modules/express/node_modules/connect/lib/middleware/urlencoded.js:52:72)
</code>
