### PR TITLE
Reverted enableDeviceHelpers to previous version

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -78,30 +78,62 @@ exports.capture = function () {
     };
 };
 
-function deviceFactory(type) {
+express.application.enableDeviceHelpers = function () {
+    var app = this.app || this;
     var check_request = function (req) {
         if (typeof req.device === 'undefined') {
             throw new Error('Must enable the device capture by using app.use(device.capture())');
         }
+
         return true;
     };
-    return function (req, res, next) {
+
+    var is_desktop = function (req, res, next) {
         check_request(req);
-        res.locals['is_' + type] = req.device.type === type;
+        res.locals.is_desktop = req.device.type === 'desktop';
         if (next) {
             next();
         }
     };
-}
-
-express.application.enableDeviceHelpers = function () {
-    var app = this.app || this,
-        types = ['desktop', 'mobile', 'phone', 'tablet', 'tv'],
-        i,
-        type;
-
-    for (i = 0; i < types.length; i + 1) {
-        type = types[i];
-        app.use(deviceFactory(type));
-    }
+    app.use(is_desktop);
+    var is_mobile = function (req, res, next) {
+        check_request(req);
+        res.locals.is_mobile = req.device.type === 'phone' || req.device.type === 'tablet';
+        if (next) {
+            next();
+        }
+    };
+    app.use(is_mobile);
+    var is_phone = function (req, res, next) {
+        check_request(req);
+        res.locals.is_phone = req.device.type === 'phone';
+        if (next) {
+            next();
+        }
+    };
+    app.use(is_phone);
+    var is_tablet = function (req, res, next) {
+        check_request(req);
+        res.locals.is_tablet = req.device.type === 'tablet';
+        if (next) {
+            next();
+        }
+    };
+    app.use(is_tablet);
+    var is_tv = function (req, res, next) {
+        check_request(req);
+        res.locals.is_tv = req.device.type === 'tv';
+        if (next) {
+            next();
+        }
+    };
+    app.use(is_tv);
+    var device_type = function (req, res, next) {
+        check_request(req);
+        res.locals.device_type = req.device.type;
+        if (next) {
+            next();
+        }
+    };
+    app.use(device_type);
 };


### PR DESCRIPTION
 ...because it spawned an endless loop in express. I currently don't know why, I'm investigating it, I think it's some kind of scope/reference issue. Sorry for that, I did relay to much on the test cases... I will try refactor it again when I found the reason for the loop and add a express template test case
