### PR TITLE
refactor enableViewRouting and app enableDeviceHelpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## why express-device?
 
-I'm really into node.js and lately I've been playing a lot with it. One of the steps I wanted to take in my learning path was to build a node.js module and published it to npm. 
+I'm really into node.js and lately I've been playing a lot with it. One of the steps I wanted to take in my learning path was to build a node.js module and published it to npm.
 
 Then I had an idea: why not develop a server side library to mimic the behaviour that Twitter's [Bootstrap](http://twitter.github.com/bootstrap/scaffolding.html#responsive) has in order to identify where a browser is running on a desktop, tablet or phone. This is great for a [responsive design](http://en.wikipedia.org/wiki/Responsive_Web_Design), but on the server side.
 
@@ -21,11 +21,11 @@ But then I came across with Brett Jankord's [blog](http://www.brettjankord.com).
 ## how to use it?
 
 To install it you only need to do:
- 
+
     $ npm install express-device
-    
+
 Case you're using [express](http://expressjs.com/) 2.x.x you should install version 0.1.2:
- 
+
     $ npm install express-device@0.1.2
 
 express-device is built on top of [express](http://expressjs.com/) framework. Here's an example on how to configure express to use it:
@@ -35,7 +35,7 @@ app.configure(function(){
     app.set('view engine', 'ejs');
     app.set('view options', { layout: false });
     app.set('views', __dirname + '/views');
-    
+
     app.use(express.bodyParser());
     app.use(device.capture());
 });
@@ -105,7 +105,7 @@ express-device can also add some variables to the response [locals property](htt
         <td>It returns the device type string parsed from the request</td>
     </tr>
 </table>
-In order to enable this methods you have to call **app.enableDeviceHelpers()**, just before **app.use(app.router)**.
+In order to enable this method you have to pass the app reference to **device.enableDeviceHelpers(app)**, just before **app.use(app.router)**.
 
 Here's an example on how to use them (using [EJS](https://github.com/visionmedia/ejs) view engine):
 ```html
@@ -136,7 +136,7 @@ Here's an example on how to use them (using [EJS](https://github.com/visionmedia
 
 You can check a full working example [here](https://github.com/rguerreiro/express-device/tree/master/example).
 
-In version 0.3.0 a cool feature was added: the ability to route to a specific view\layout based on the device type (must call the **app.enableViewRouting()** to set it up). Consider the code below:
+In version 0.3.0 a cool feature was added: the ability to route to a specific view\layout based on the device type (you must pass the app reference to **.device.enableViewRouting(app)** to set it up). Consider the code below:
 
     .
     |-- views
@@ -152,11 +152,11 @@ app.configure(function(){
     app.set('view engine', 'ejs');
     app.set('view options', { layout: true });
     app.set('views', __dirname + '/views');
-    
+
     app.use(express.bodyParser());
     app.use(device.capture());
 
-    app.enableViewRouting();
+    device.enableViewRouting(app);
 });
 
 app.get('/', function(req, res) {
@@ -179,11 +179,11 @@ app.configure(function(){
     app.set('view engine', 'ejs');
     app.set('view options', { layout: true });
     app.set('views', __dirname + '/views');
-    
+
     app.use(express.bodyParser());
     app.use(device.capture());
 
-    app.enableViewRouting({
+    device.enableViewRouting(app, {
     	"noPartials":true
     });
 });

--- a/example/app.js
+++ b/example/app.js
@@ -1,6 +1,6 @@
 var express = require('express'),
     device  = require('../');
-    
+
 var app = express();
 var port = process.env.PORT || 3000;
 
@@ -8,14 +8,14 @@ app.configure(function(){
     app.set('view engine', 'ejs');
     app.set('view options', { layout: true });
     app.set('views', __dirname + '/views');
-    
+
     app.use(express.bodyParser());
     app.use(express.methodOverride());
     app.use(express.cookieParser());
     app.use(device.capture());
-    
-    app.enableDeviceHelpers();
-    app.enableViewRouting();
+
+    device.enableDeviceHelpers(app);
+    device.enableViewRouting(app);
 
     app.use(app.router);
 });

--- a/lib/device.js
+++ b/lib/device.js
@@ -11,7 +11,7 @@ var defaultOptions = {
 
 exports.version = require('../package').version;
 exports.namespace = 'express';
- 
+
 function merge(obj1, obj2) {
     var obj3 = {};
     if(obj1) { for (var attrname in obj1) { obj3[attrname] = obj1[attrname]; } }
@@ -30,7 +30,7 @@ function DeviceParser(req, options) {
 
     self.get_type = function () {
         var ua = self.user_agent();
-        
+
         if (!ua || ua === '') {
             // No user agent.
             return self.options.emptyUserAgentDeviceType;
@@ -97,15 +97,7 @@ exports.capture = function (options) {
     };
 };
 
-function check (req, res, name) {
-    var ext = path.extname(name) || '.' + (res.app.get('view engine') || 'html');
-    var root = req.app.get('views') || process.cwd() + '/views';
-    var dir = path.dirname(name) == '.' ? root : path.resolve(root, path.dirname(name));
-    return partials.lookup(dir, path.basename(name, ext), ext);
-}
-
-express.application.enableViewRouting = function (options) {
-    var app = this.app || this;
+exports.enableViewRouting = function (app, options) {
     if(!options || options.noPartials === false)
         app.use(partials());
     app.use(function (req, res, next) {
@@ -119,12 +111,12 @@ express.application.enableViewRouting = function (options) {
                     var defaultLayout = path.join(req.device.type, 'layout');
                     options = options || {};
                     if (check(req, res, defaultLayout)) options.layout = defaultLayout;
-                } 
+                }
                 else if(typeof layout === "string") {
                     var deviceLayout = path.join(req.device.type, layout);
                     if (check(req, res, deviceLayout)) options.layout = deviceLayout;
                 }
-    
+
                 var deviceView = path.join(req.device.type, name);
                 if (check(req, res, deviceView)) name = deviceView;
             }
@@ -136,8 +128,7 @@ express.application.enableViewRouting = function (options) {
     });
 };
 
-express.application.enableDeviceHelpers = function () {
-    var app = this.app || this;
+exports.enableDeviceHelpers = function (app) {
     var check_request = function (req) {
         if (typeof req.device === 'undefined') {
             throw new Error('Must enable the device capture by using app.use(device.capture())');
@@ -203,3 +194,10 @@ express.application.enableDeviceHelpers = function () {
     };
     app.use(device_type);
 };
+
+function check (req, res, name) {
+    var ext = path.extname(name) || '.' + (res.app.get('view engine') || 'html');
+    var root = req.app.get('views') || process.cwd() + '/views';
+    var dir = path.dirname(name) == '.' ? root : path.resolve(root, path.dirname(name));
+    return partials.lookup(dir, path.basename(name, ext), ext);
+}

--- a/test/app/app.js
+++ b/test/app/app.js
@@ -7,8 +7,8 @@ app.set('view options', { layout: true });
 app.set('views', __dirname);
 
 app.use(device.capture());
-app.enableDeviceHelpers();
-app.enableViewRouting();
+device.enableDeviceHelpers(app);
+device.enableViewRouting(app);
 
 app.get('/', function(req, res, next) {
     res.render('index.ejs');

--- a/test/app_no_partials/app.js
+++ b/test/app_no_partials/app.js
@@ -6,8 +6,9 @@ app.set('view engine', 'ejs');
 app.set('views', __dirname);
 
 app.use(device.capture());
-app.enableDeviceHelpers();
-app.enableViewRouting({ noPartials: true });
+
+device.enableDeviceHelpers(app);
+device.enableViewRouting(app, { noPartials: true });
 
 app.get('/helpers', function(req, res, next) {
     res.render('index_helpers.ejs');


### PR DESCRIPTION
I ran into the same issue as #20

I did some digging and found that device was attaching enableViewRouting and enableDeviceHelpers to the local version of express in its own node_modules, which doesn't affect express further up in the root node_modules or global node_modules since they are stored differently in the require.cache.

This refactor solves that issue by passing the reference to the individual app instead of affecting all apps.This approach also benefits cases where you have more than one express applications listening on different ports in the same script (ex SSL). Since the previous method modified the prototype, it would apply the extra middleware to every instance of app. This also prevents any possible breaking changes from express since it doesn't modify the app's prototype.
