### PR TITLE
Remove redundant dependency on express in ./lib/device/js

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -1,6 +1,5 @@
 /* Based on Categorizr (https://github.com/bjankord/Categorizr) by Brett Jankord (http://www.brettjankord.com) */
-var express     = require('express'),
-    path        = require('path'),
+var path        = require('path'),
     partials    = require('express-partials'),
     useragent   = require('useragent');
 

--- a/package.json
+++ b/package.json
@@ -2,21 +2,39 @@
   "name": "express-device",
   "author": "Rodrigo Guerreiro (@rguerreiro)",
   "description": "Browser detection library, built on top of express",
-  "keywords": [ "browser", "mobile", "detection", "user-agent", "useragent", "express", "layout", "view routing", "desktop", "phone", "tablet", "tv", "bot", "responsive design", "parsing" ],
+  "keywords": [
+    "browser",
+    "mobile",
+    "detection",
+    "user-agent",
+    "useragent",
+    "express",
+    "layout",
+    "view routing",
+    "desktop",
+    "phone",
+    "tablet",
+    "tv",
+    "bot",
+    "responsive design",
+    "parsing"
+  ],
   "version": "0.4.1",
   "main": "./index.js",
   "private": false,
-  "engines": { "node": ">=0.10" },
+  "engines": {
+    "node": ">=0.10"
+  },
   "dependencies": {
-    "express": "4.x.x",
     "express-partials": "0.3.0",
     "useragent": "*"
   },
   "devDependencies": {
-    "cookie-parser": "*",
-    "method-override": "*",
     "body-parser": "*",
+    "cookie-parser": "*",
     "ejs": "*",
+    "express": "^4.13.3",
+    "method-override": "*",
     "mocha": "*",
     "supertest": "*"
   },


### PR DESCRIPTION
express was being required in lib/device.js but not actually used. Since it is also declared as a prod dependency it will be installed for all implementations and so will potentially unnecessarily bloat the dependency tree.

Moving the dependency to a dev dependency allows the files still to be tested in an express context for development, but will not result in an additional and potentially redundant installation for production implementations.