### PR TITLE
Reduce repetition in deviceHelpers code

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -157,64 +157,40 @@ exports.enableViewRouting = function (app, options) {
 };
 
 exports.enableDeviceHelpers = function (app) {
-    var check_request = function (req) {
+
+    var check_request = function (req, res, next) {
         if (typeof req.device === 'undefined') {
-            throw new Error('Must enable the device capture by using app.use(device.capture())');
-        }
-
-        return true;
-    };
-
-    var is_desktop = function (req, res, next) {
-        check_request(req);
-        res.locals.is_desktop = req.device.type === 'desktop';
-        if (next) {
+            next(new Error('Must enable the device capture by using app.use(device.capture())'));
+        } else {
             next();
         }
     };
-    app.use(is_desktop);
+    app.use(check_request);
+
+    var check_device = function (device) {
+        return function (req, res, next) {
+            res.locals['is_' + device] = req.device.type === device;
+            if (next) {
+                next();
+            }
+        }
+    }
+
+    app.use(check_device('desktop'));
+    app.use(check_device('phone'));
+    app.use(check_device('tablet'));
+    app.use(check_device('tv'));
+    app.use(check_device('bot'));
+
     var is_mobile = function (req, res, next) {
-        check_request(req);
-        res.locals.is_mobile = req.device.type === 'phone' || req.device.type === 'tablet';
+        res.locals.is_mobile = res.locals.is_phone || res.locals.is_tablet;
         if (next) {
             next();
         }
     };
     app.use(is_mobile);
-    var is_phone = function (req, res, next) {
-        check_request(req);
-        res.locals.is_phone = req.device.type === 'phone';
-        if (next) {
-            next();
-        }
-    };
-    app.use(is_phone);
-    var is_tablet = function (req, res, next) {
-        check_request(req);
-        res.locals.is_tablet = req.device.type === 'tablet';
-        if (next) {
-            next();
-        }
-    };
-    app.use(is_tablet);
-    var is_tv = function (req, res, next) {
-        check_request(req);
-        res.locals.is_tv = req.device.type === 'tv';
-        if (next) {
-            next();
-        }
-    };
-    app.use(is_tv);
-    var is_bot = function (req, res, next) {
-        check_request(req);
-        res.locals.is_bot = req.device.type === 'bot';
-        if (next) {
-            next();
-        }
-    };
-    app.use(is_bot);
+
     var device_type = function (req, res, next) {
-        check_request(req);
         res.locals.device_type = req.device.type;
         if (next) {
             next();
@@ -222,7 +198,6 @@ exports.enableDeviceHelpers = function (app) {
     };
     app.use(device_type);
     var device_name = function (req, res, next) {
-        check_request(req);
         res.locals.device_name = req.device.name;
         if (next) {
             next();


### PR DESCRIPTION
Previous code path was executing the check for req.device several times per request. Moving this to a single, up-front middleware reduces the number of calls through this function down to one.

The device type checking middlewares all contained identical code, save for the device type, so pass these into a single generating function to reduce repetitive code paths.