### PR TITLE
[Fix] Checking for Amazon Cloudfront user-agent

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -17,20 +17,34 @@ exports.version = require('../package').version;
 exports.namespace = 'express';
 exports.Parser = device.Parser;
 
-// should this be on 'device' instead?
+const cloudFrontHeaders = {
+    phone: 'cloudfront-is-mobile-viewer',
+    tablet: 'cloudfront-is-tablet-viewer',
+    desktop: 'cloudfront-is-desktop-viewer',
+    userAgent: 'Amazon CloudFront',
+};
+  
+/**
+ * @param {*} req
+ * @param {*} mydevice
+ * @description Checks device type based on cloudfront viewer headers
+ * In Prod cloudfront removes the user-agent, adds one of the
+ * the viewer headers and switches user-agent to Amazon CloudFront
+ * to improve caching.
+ * @returns one of ['phone', 'tablet', 'desktop']
+ */
 function customCheck(req, mydevice) {
-    var useragent = req.headers['user-agent'];
+    const useragent = req.headers['user-agent'];
 
-    if (!useragent || useragent === '') {
-        if (req.headers['cloudfront-is-mobile-viewer'] === 'true') return 'phone';
-        if (req.headers['cloudfront-is-tablet-viewer'] === 'true') return 'tablet';
-        if (req.headers['cloudfront-is-desktop-viewer'] === 'true') return 'desktop';
-        // No user agent.
+    if (!useragent || useragent === cloudFrontHeaders.userAgent) {
+        if (req.headers[cloudFrontHeaders.phone] === 'true') return 'phone';
+        if (req.headers[cloudFrontHeaders.tablet] === 'true') return 'tablet';
+        if (req.headers[cloudFrontHeaders.desktop] === 'true') return 'desktop';
         return mydevice.parser.options.emptyUserAgentDeviceType;
     }
 
     return mydevice.type;
-};
+}
 exports.customCheck = customCheck;
 
 function capture(options) {

--- a/test/cloudfront_test.js
+++ b/test/cloudfront_test.js
@@ -1,22 +1,76 @@
-var device = require('../lib/device.js'),
-    assert = require('assert');
+const device = require('device');
+const expressDevice = require('../lib/device.js');
+const assert = require('assert');
 
 describe('cloudfront', function() {
-    describe('with desktop header',function(){
-        it('should get device type desktop', function(){
-            var type = device.customCheck({ headers: { 'cloudfront-is-desktop-viewer': 'true' } });
+    let headers = {};
+
+    describe('with user-agent is present', () => {
+        const mockUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) Chrome/65.0.3325.146';
+        beforeEach(() => { headers = { 'user-agent': mockUserAgent }; });
+        afterEach(() => { headers = {}; });
+
+        describe('with cloudfront user agent', () => {
+            beforeEach(() => { headers = { ...headers, 'user-agent': 'Amazon CloudFront' }; });
+            afterEach(() => { headers = {}; });
+            
+            describe('with desktop viewer', () => {
+                beforeEach(() => { headers = { ...headers, 'cloudfront-is-desktop-viewer': 'true' } });
+
+                it('should get device type desktop', () => {
+                    const type = expressDevice.customCheck({ headers })
+                    assert.equal(type, 'desktop');
+                });
+            });
+            describe('with mobile viewer', () => {
+                beforeEach(() => { headers = { ...headers, 'cloudfront-is-mobile-viewer': 'true' } });
+
+                it('should get device type phone', function () {
+                    const type = expressDevice.customCheck({ headers })
+                    assert.equal(type, 'phone');
+                });
+            });
+            describe('with tablet viewer', () => {
+                beforeEach(() => { headers = { ...headers, 'cloudfront-is-tablet-viewer': 'true' } });
+
+                it('should get device type tablet', function () {
+                    const type = expressDevice.customCheck({ headers })
+                    assert.equal(type, 'tablet');
+                });
+            });
+        });
+
+        it('should return the present device type', () => {
+            const mydevice = device(mockUserAgent, {});
+            const type = expressDevice.customCheck({ headers: { ...headers, 'cloudfront-is-phone-viewer': 'true' } }, mydevice);
+            assert.equal(type, mydevice.type);
+        });
+    });
+
+    describe('with desktop viewer', () => {
+        beforeEach(() => { headers = { ...headers, 'cloudfront-is-desktop-viewer': 'true' } });
+        afterEach(() => { headers = {}; });
+
+        it('should get device type desktop', () => {
+            const type = expressDevice.customCheck({ headers })
             assert.equal(type, 'desktop');
         });
     });
-    describe('with mobile viewer', function () {
+    describe('with mobile viewer', () => {
+        beforeEach(() => { headers = { ...headers, 'cloudfront-is-mobile-viewer': 'true' } });
+        afterEach(() => { headers = {}; });
+
         it('should get device type phone', function () {
-            var type = device.customCheck({ headers: { 'cloudfront-is-mobile-viewer': 'true' } });
+            const type = expressDevice.customCheck({ headers })
             assert.equal(type, 'phone');
         });
     });
-    describe('with tablet viewer', function () {
+    describe('with tablet viewer', () => {
+        beforeEach(() => { headers = { ...headers, 'cloudfront-is-tablet-viewer': 'true' } });
+        afterEach(() => { headers = {}; });
+
         it('should get device type tablet', function () {
-            var type = device.customCheck({ headers: { 'cloudfront-is-tablet-viewer': 'true' } });
+            const type = expressDevice.customCheck({ headers })
             assert.equal(type, 'tablet');
         });
     });


### PR DESCRIPTION
Instead of removing the user agent, CloudFront resets it to
`Amazon CloudFront`. This behavior can be tested within a container
running behind Cloudfront by instrumenting the device.js file and
logging the headers:
```yml
user-agent: Amazon CloudFront
req[headers]: {
  ...
  'cloudfront-is-desktop-viewer': 'true',
  'cloudfront-is-mobile-viewer': 'false',
  'cloudfront-is-tablet-viewer': 'false',
   ....
  'user-agent': 'Amazon CloudFront',
  ...
  connection: 'close' }
```

See [CloudFront User-Agent docs](https://goo.gl/S5ojzM)